### PR TITLE
Make listener its own component and use fake listening

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web:    node src/main production server
+web:    node src/main server

--- a/config.yml
+++ b/config.yml
@@ -1,13 +1,13 @@
 defaults:
   taskcluster:
-    rootUrl:        https://taskcluster-events-staging.herokuapp.com/ 
+    rootUrl:        !env TASKCLUSTER_ROOT_URL
     credentials:
       clientId:     !env TASKCLUSTER_CLIENT_ID
       accessToken:  !env TASKLCSUTER_ACCESS_TOKEN
   
   server:
     port:           !env:number PORT
-    env:            !env NODE_ENV
+    env:            'development'
     forceSSL:       !env:flag FORCE_SSL
     trustProxy:     false
   
@@ -31,19 +31,11 @@ production:
     mock:           false
 
 test:
-  taskcluster:
-    rootUrl:        http://localhost:12345
-
   monitor:
     enable:         false
 
   server:
     port:           12345
-    env:            development
 
   pulse:
-    username:       !env PULSE_USERNAME
-    password:       !env PULSE_PASSWORD
-    hostname:       pulse.mozilla.org
-    vhost:          /
-
+    fake:           true

--- a/src/api.js
+++ b/src/api.js
@@ -95,10 +95,13 @@ builder.declare({
     debug('Bindings parsed');
     var listener = await this.listeners.createListener(json_bindings);
     sendEvent('ready');
-    debug('listener created', listener);
+    const idleMessage = {code:404, message:'No messages received for 20s. Aborting...'};
+    let idleTimeout = setTimeout(() => abort(idleMessage), 20*1000);
     
     listener.on('message', message => {
       sendEvent('message', message.payload);
+      clearTimeout(idleTimeout);
+      idleTimeout = setTimeout(() => abort(idleMessage), 20*1000);  
     });
 
     pingEvent = setInterval(() => sendEvent('ping', {
@@ -153,3 +156,4 @@ builder.declare({
 
 // Export api
 module.exports = builder;
+    

--- a/src/api.js
+++ b/src/api.js
@@ -19,8 +19,8 @@ let builder = new APIBuilder({
 
 // Returns JSON.parse(bindings) if everything goes well
 //   {"bindings" : [ 
-//     {"exchange" :  "a/b/c", "routingKey" : "a.b.c"},
-//     {"exchange" :  "x/y/z", "routingKey" : "x.y.z"},
+//     {"exchange" :  "a/b/c", "routingKeyPattern" : "a.b.c"},
+//     {"exchange" :  "x/y/z", "routingKeyPattern" : "x.y.z"},
 //   ]};
 var parseAndValidateBindings = function(bindings) {
   return new Promise((resolve, reject) => {
@@ -33,11 +33,11 @@ var parseAndValidateBindings = function(bindings) {
       // Reduce json_bindings to an array of exchanges.
       json_bindings = json_bindings.bindings;
       if (!Array.isArray(json_bindings)) {
-        throw new Error('Bindings must be an array of {exchange, routingKey}');
+        throw new Error('Bindings must be an array of {exchange, routingKeyPattern}');
       }
       _.forEach(json_bindings, binding => {
-        if (!('routingKey' in binding) || !('exchange' in binding)) {
-          throw new Error('Binding must include `exchange` and `routingKey` fields');
+        if (!('routingKeyPattern' in binding) || !('exchange' in binding)) {
+          throw new Error('Binding must include `exchange` and `routingKeyPattern` fields');
         }
       });
       resolve(json_bindings);

--- a/src/api.js
+++ b/src/api.js
@@ -94,7 +94,8 @@ builder.declare({
     let json_bindings = await parseAndValidateBindings(req.query.bindings);
     debug('Bindings parsed');
     var listener = await this.listeners.createListener(json_bindings);
-    debug('listener created');
+    sendEvent('ready');
+    debug('listener created', listener);
     
     listener.on('message', message => {
       sendEvent('message', message.payload);

--- a/src/api.js
+++ b/src/api.js
@@ -99,7 +99,7 @@ builder.declare({
     let idleTimeout = setTimeout(() => abort(idleMessage), 20*1000);
     
     listener.on('message', message => {
-      sendEvent('message', message.payload);
+      sendEvent('message', message);
       clearTimeout(idleTimeout);
       idleTimeout = setTimeout(() => abort(idleMessage), 20*1000);  
     });

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -45,7 +45,7 @@ Listeners.prototype.createListener = async function(bindings) {
 
     this.listeners.push(listener);
     await listener.resume();
-    
+
     return listener;
   } catch (err) {
     err.code = 404;
@@ -57,7 +57,7 @@ Listeners.prototype.createListener = async function(bindings) {
 
 /** Close and remove listener from this.listeners */
 Listeners.prototype.closeListener = function(listener) {
-  let removeIndex = this.listeners.map(item => {return item._queueName;}).indexOf(listener._queueName);
+  let removeIndex = this.listeners.findIndex(({_queueName}) => listener._queueName === _queueName);
   if (removeIndex > -1) {
     listener.close();
     this.listeners.splice(removeIndex, 1);

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -25,7 +25,6 @@ Listeners.prototype.setup = function() {
   assert(this.listeners === null, 'Cannot setup twice');
 
   this.connection = new taskcluster.PulseConnection(this.credentials);
-  debug(this.connection);
   this.listeners = [];
 };
 
@@ -45,17 +44,15 @@ Listeners.prototype.createListener = async function(bindings) {
     }));
 
     this.listeners.push(listener);
-
     await listener.resume();
+    
     return listener;
-
   } catch (err) {
     err.code = 404;
     debug(err);
     this.closeListener(listener);
     throw err;
   }
-
 };
 
 /** Close and remove listener from this.listeners */

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -41,7 +41,7 @@ class Listeners {
 
       _.forEach(bindings, binding => listener.bind({
         exchange:          binding.exchange,
-        routingKeyPattern: binding.routingKey,  
+        routingKeyPattern: binding.routingKeyPattern,  
       }));
 
       this.listeners.push(listener);

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -1,0 +1,60 @@
+var assert      = require('assert');
+var taskcluster = require('taskcluster-client');
+var debug       = require('debug')('events:listeners');
+var _           = require('lodash');
+
+/**
+ * Create Listener and Handle Events
+ *
+ * options:
+ * {
+ *   credentials:        // Pulse credentials
+ * }
+ */
+var Listeners = function(options) {
+  assert(options.credentials, 'Pulse credentials must be provided');
+
+  this.credentials    = options.credentials;
+  this.connection     = null
+  this.pulseListeners = null;
+}
+
+/** Setup the PulseConnection */
+Listeners.prototype.setup = function() {
+  assert(this.listeners === null, 'Cannot setup twice');
+
+  this.connection = new taskcluster.PulseConnection(this.credentials);
+  this.listeners = [];
+};
+
+Listeners.prototype.createListener = function(bindings) {
+  let listener = new taskcluster.PulseListener({
+    prefetch:   5,
+    connection: this.connection,
+    maxLength:  50,
+  });
+
+  _.forEach(bindings, binding => listener.bind({
+    exchange:          binding.exchange,
+    routingKeyPattern: binding.routingKey,  
+  }));
+
+  this.listeners.push(listener);
+
+  return new Promise((resolve,reject) => {
+    listener.resume().then(
+      () => {return listener;}, err => reject(err)
+    )
+  });
+};
+
+Listeners.prototype.destroyListener = function(listener) {
+  let removeIndex = this.listeners.map( item => return item._queueName).indexOf(listener._queueName);
+  if (removeIndex > -1) {
+    listener.close();
+    this.listeners.splice(removeIndex, 1);
+  }
+}
+
+// Export Listeners
+module.exports = Listeners;

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -57,12 +57,20 @@ class Listeners {
   }
 
   /** Close and remove listener from this.listeners */
-  closeListener() {
+  closeListener(listener) {
     let removeIndex = this.listeners.findIndex(({_queueName}) => listener._queueName === _queueName);
     if (removeIndex > -1) {
       listener.close();
       this.listeners.splice(removeIndex, 1);
     }
+  }
+
+  async terminate() {
+    debug('Terminating Listeners..');
+    if (this.listeners) {
+      _.forEach(this.listeners, listener => this.closeListener(listener));
+    }
+    this.listeners = undefined;
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -67,10 +67,9 @@ let load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  console.log(process.argv);
-  load(process.argv[3], {
-    process: process.argv[3],
-    profile: process.argv[2],
+  load(process.argv[2], {
+    process: process.argv[2],
+    profile: process.env.NODE_ENV,
   }).catch(err => {
     console.log(err.stack);
     process.exit(1);

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ let debug = require('debug')('events:main');
 let config = require('typed-env-config');
 let builder = require('./api');
 let taskcluster = require('taskcluster-client');
-let Listeners = require('./listeners.js');
+let Listeners = require('./listeners');
 let _  = require('lodash');
 
 // Create component loader
@@ -46,7 +46,7 @@ let load = loader({
     setup : ({cfg, monitor, listeners}) => builder.build({
       rootUrl:  cfg.taskcluster.rootUrl,
       context:  {
-        listeners:  listeners,
+        listeners,
       },
       monitor:  monitor.prefix('api'),
     }),

--- a/test/bad_input_test.js
+++ b/test/bad_input_test.js
@@ -9,7 +9,7 @@ helper.secrets.mockSuite(__filename, [], function(mock, skipping) {
 
   test('More than one key in query', async () => {
     let bindings = {bindings : [ 
-      {exchange :  'exchange/taskcluster-foo/v1/bar', routingKey : '#'},
+      {exchange :  'exchange/taskcluster-foo/v1/bar', routingKeyPattern : '#'},
     ], foo: 'bar'};
 
     let {evtSource, resolve, pass, fail} = helper.connect(bindings);
@@ -23,12 +23,12 @@ helper.secrets.mockSuite(__filename, [], function(mock, skipping) {
   });
 
   test('Bindings is not an array', async () => {
-    let bindings = {bindings : {exchange :  'exchange/taskcluster-foo/v1/bar', routingKey : '#'}};
+    let bindings = {bindings : {exchange :  'exchange/taskcluster-foo/v1/bar', routingKeyPattern : '#'}};
 
     let {evtSource, resolve, pass, fail} = helper.connect(bindings);
 
     evtSource.addEventListener('error', (e) => {
-      assert(_.includes(e.data, 'Bindings must be an array of {exchange, routingKey}'));
+      assert(_.includes(e.data, 'Bindings must be an array of {exchange, routingKeyPattern}'));
       evtSource.close();
       pass();
     });

--- a/test/bad_input_test.js
+++ b/test/bad_input_test.js
@@ -1,13 +1,15 @@
-suite('Failed Input Validation', function() {
-  let debug       = require('debug')('test:bad_input');
-  let assert      = require('assert');
-  let helper = require('./helper');
-  let _ = require('lodash');
+const debug     = require('debug')('test:get_msg');
+const assert    = require('assert');
+const helper    = require('./helper');
+const _         = require('lodash');
 
-  // Wrong exchange. Should get 404
+helper.secrets.mockSuite(__filename, [], function(mock, skipping) {
+  helper.withPulse(mock, skipping);
+  helper.withServer(mock, skipping);
+
   test('More than one key in query', async () => {
     let bindings = {bindings : [ 
-      {exchange :  'exchange/random/does-not-exist', routingKey : '#'},
+      {exchange :  'exchange/taskcluster-foo/v1/bar', routingKey : '#'},
     ], foo: 'bar'};
 
     let controls = helper.connect(bindings);
@@ -24,7 +26,7 @@ suite('Failed Input Validation', function() {
   });
 
   test('Bindings is not an array', async () => {
-    let bindings = {bindings : {exchange :  'exchange/random/does-not-exist', routingKey : '#'}};
+    let bindings = {bindings : {exchange :  'exchange/taskcluster-foo/v1/bar', routingKey : '#'}};
 
     let controls = helper.connect(bindings);
     //controls = {es, resolve, pass, fail}
@@ -33,24 +35,6 @@ suite('Failed Input Validation', function() {
     es.addEventListener('error', (e) => {
       error = e.data;
       assert(_.includes(error, 'Bindings must be an array of {exchange, routingKey}'));
-      es.close();
-      controls.pass();
-    });
-    await controls.resolve;
-  });
-
-  test.skip('A binding has more than 2 fields', async () => {
-    let bindings = {bindings : [ 
-      {exchange :  'exchange/random/does-not-exist', routingKey : '#', foo : 'bar'},
-    ]};
-
-    let controls = helper.connect(bindings);
-    //controls = {es, resolve, pass, fail}
-    let es = controls.es;
-
-    es.addEventListener('error', (e) => {
-      error = e.data;
-      assert(_.includes(error, 'Each binding must have only two fields - exchange and routingKey'));
       es.close();
       controls.pass();
     });

--- a/test/bad_input_test.js
+++ b/test/bad_input_test.js
@@ -12,33 +12,27 @@ helper.secrets.mockSuite(__filename, [], function(mock, skipping) {
       {exchange :  'exchange/taskcluster-foo/v1/bar', routingKey : '#'},
     ], foo: 'bar'};
 
-    let controls = helper.connect(bindings);
-    //controls = {es, resolve, pass, fail}
-    let es = controls.es;
+    let {evtSource, resolve, pass, fail} = helper.connect(bindings);
 
-    es.addEventListener('error', (e) => {
-      error = e.data;
-      assert(_.includes(error, 'The json query should have only one key'));
-      es.close();
-      controls.pass();
+    evtSource.addEventListener('error', (e) => {
+      assert(_.includes(e.data, 'The json query should have only one key'));
+      evtSource.close();
+      pass();
     });
-    await controls.resolve;
+    await resolve;
   });
 
   test('Bindings is not an array', async () => {
     let bindings = {bindings : {exchange :  'exchange/taskcluster-foo/v1/bar', routingKey : '#'}};
 
-    let controls = helper.connect(bindings);
-    //controls = {es, resolve, pass, fail}
-    let es = controls.es;
+    let {evtSource, resolve, pass, fail} = helper.connect(bindings);
 
-    es.addEventListener('error', (e) => {
-      error = e.data;
-      assert(_.includes(error, 'Bindings must be an array of {exchange, routingKey}'));
-      es.close();
-      controls.pass();
+    evtSource.addEventListener('error', (e) => {
+      assert(_.includes(e.data, 'Bindings must be an array of {exchange, routingKey}'));
+      evtSource.close();
+      pass();
     });
-    await controls.resolve;
+    await resolve;
   });
 
 });

--- a/test/getmsg_test.js
+++ b/test/getmsg_test.js
@@ -29,7 +29,7 @@ suite('Get messages', function() {
   });
 
   // Wrong exchange. Should get 404
-  test('Exchange does not exist', async () => {
+  test.skip('Exchange does not exist', async () => {
     let bindings = {bindings : [ 
       {exchange :  'exchange/random/does-not-exist', routingKey : '#'},
     ]};

--- a/test/getmsg_test.js
+++ b/test/getmsg_test.js
@@ -9,7 +9,7 @@ helper.secrets.mockSuite(__filename, [], function(mock, skipping) {
 
   test('Exchange is correct', async () => {
     let bindings = {bindings : [ 
-      {exchange :  'exchange/taskcluster-foo/v1/bar', routingKey : '#'},
+      {exchange :  'exchange/taskcluster-foo/v1/bar', routingKeyPattern : '#'},
     ]};
 
     let {evtSource, resolve, pass, fail} = helper.connect(bindings);
@@ -47,7 +47,7 @@ helper.secrets.mockSuite(__filename, [], function(mock, skipping) {
     // Send no messages after connecting. The connection should be 
     // closed automatically after 20s 
     let bindings = {bindings : [ 
-      {exchange :  'exchange/taskcluster-foo/v1/bar', routingKey : '#'},
+      {exchange :  'exchange/taskcluster-foo/v1/bar', routingKeyPattern : '#'},
     ]};
     
     let {evtSource, resolve, pass, fail} = helper.connect(bindings);

--- a/test/getmsg_test.js
+++ b/test/getmsg_test.js
@@ -23,12 +23,11 @@ helper.secrets.mockSuite(__filename, [], function(mock, skipping) {
           status: 'fooIsBar',
         },
       };
-
       _.last(helper.listeners).fakeMessage(message);
     });
 
     evtSource.addEventListener('message', (msg) => {
-      assert(JSON.parse(msg.data).status === 'fooIsBar');
+      assert(JSON.parse(msg.data).payload.status === 'fooIsBar');
       evtSource.close();
       pass();
     });

--- a/test/helper.js
+++ b/test/helper.js
@@ -72,9 +72,8 @@ exports.withServer = (mock, skipping) => {
 
     helper.connect = bindings => {
       let json = urlencode(JSON.stringify(bindings));
+      debug('Connecting to api...');
       const evtSource = new EventSource(libUrls.api(helper.rootUrl, 'events', 'v1', '/connect/?bindings=')+json);
-      debug(libUrls.api(helper.rootUrl, 'events', 'v1', '/connect/?bindings')+json);
-      debug('trying to connect to api');
       let pass, fail;
       const resolve = new Promise((resolve, reject) => {
         pass = resolve;
@@ -89,12 +88,6 @@ exports.withServer = (mock, skipping) => {
     };
 
     webServer = await helper.load('server');
-  });
-
-  setup(async function() {
-    if (skipping()) {
-      return;
-    }
   });
 
   suiteTeardown(async function() {

--- a/test/helper.js
+++ b/test/helper.js
@@ -34,14 +34,25 @@ helper.rootUrl = 'http://localhost:12345';
 * and add that to helper.listeners .
 */
 exports.withPulse = (mock, skipping) => {
+  let Listener;
   suiteSetup(async function() {
     if (skipping()) {
       return;
     }
 
     helper.load.cfg('pulse.fake', true);
-    const Listener = await helper.load('listeners');
+    Listener = await helper.load('listeners');
     helper.listeners = Listener.listeners;
+  });
+
+  suiteTeardown(async function() {
+    if (skipping()) {
+      return;
+    }
+    if (Listener) {
+      await Listener.terminate();
+      Listener = null;
+    }
   });
 };
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,49 +1,95 @@
-let mocha           = require('mocha');
-let debug           = require('debug')('test:helper');
-let load            = require('../src/main');
-let config          = require('typed-env-config');
-let testing         = require('taskcluster-lib-testing');
-let urlencode       = require('urlencode');
-let EventSource = require('eventsource');
-
-const profile = 'test';
-let loadOptions = {profile, process: 'test'};
+const mocha           = require('mocha');
+const debug           = require('debug')('test:helper');
+const load            = require('../src/main');
+const urlencode       = require('urlencode');
+const EventSource     = require('eventsource');
+const libUrls = require('taskcluster-lib-urls');
+const {stickyLoader, Secrets} = require('taskcluster-lib-testing');
 
 // Create and export helper object
-var helper = module.exports = {load, loadOptions};
+const helper = module.exports;
 
-// Load configuration
-var cfg = config({profile});
+exports.load = stickyLoader(load);
 
-// Configure PulseTestReceiver
-helper.events = new testing.PulseTestReceiver(cfg.pulse, mocha);
-
-var webServer = null;
-
-// Setup before tests
-mocha.before(async () => {
-  // Create mock authentication server
-  webServer = await load('server', loadOptions);
-  debug('Server Setup');
+suiteSetup(async function() {
+  exports.load.inject('profile', 'test');
+  exports.load.inject('process', 'test');
 });
 
-helper.connect = bindings => {
-  let json = urlencode(JSON.stringify(bindings));
-  var es = new EventSource('http://localhost:12345/api/events/v1/connect/?bindings='+json);
+exports.secrets = new Secrets({
+  secretName: 'projects/taskcluster/testing/taskcluster-events',
+  secrets: {
+    taskcluster: [
+      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl',
+        mock: libUrls.testRootUrl()},
+    ],
+  },
+  load: exports.load,
+});
 
-  var pass, fail;
-  var resolve = new Promise((resolve, reject) => {pass = resolve; fail= reject;});
-  return {
-    es:      es,
-    resolve: resolve,
-    pass:    pass,
-    fail:    fail, 
-  };
+helper.rootUrl = 'http://localhost:12345';
+
+/**
+* Create the Listeners component with fake Pulselistener(s)
+* and add that to helper.listeners .
+*/
+exports.withPulse = (mock, skipping) => {
+  suiteSetup(async function() {
+    if (skipping()) {
+      return;
+    }
+
+    helper.load.cfg('pulse.fake', true);
+    const Listener = await helper.load('listeners');
+    helper.listeners = Listener.listeners;
+  });
 };
-  
-// Cleanup after tests
-mocha.after(async () => {
-  // Kill webServer
-  await webServer.terminate();
-  testing.fakeauth.stop();
-});
+
+/**
+ * Set up an API server.  Call this after withPulse, so the server
+ * uses fake listeners used to send fake messages.
+ */
+exports.withServer = (mock, skipping) => {
+  let webServer;
+
+  suiteSetup(async function() {
+    if (skipping()) {
+      return;
+    }
+    const cfg = await exports.load('cfg');
+    exports.load.cfg('taskcluster.rootUrl', helper.rootUrl);
+
+    helper.connect = bindings => {
+      let json = urlencode(JSON.stringify(bindings));
+      var es = new EventSource(libUrls.api(helper.rootUrl, 'events', 'v1', '/connect/?bindings=')+json);
+      debug(libUrls.api(helper.rootUrl, 'events', 'v1', '/connect/?bindings')+json);
+      debug('trying to connect to api');
+      var pass, fail;
+      var resolve = new Promise((resolve, reject) => {pass = resolve; fail= reject;});
+      return {
+        es:      es,
+        resolve: resolve,
+        pass:    pass,
+        fail:    fail, 
+      };
+    };
+
+    webServer = await helper.load('server');
+  });
+
+  setup(async function() {
+    if (skipping()) {
+      return;
+    }
+  });
+
+  suiteTeardown(async function() {
+    if (skipping()) {
+      return;
+    }
+    if (webServer) {
+      await webServer.terminate();
+      webServer = null;
+    }
+  });
+};

--- a/test/helper.js
+++ b/test/helper.js
@@ -72,16 +72,19 @@ exports.withServer = (mock, skipping) => {
 
     helper.connect = bindings => {
       let json = urlencode(JSON.stringify(bindings));
-      var es = new EventSource(libUrls.api(helper.rootUrl, 'events', 'v1', '/connect/?bindings=')+json);
+      const evtSource = new EventSource(libUrls.api(helper.rootUrl, 'events', 'v1', '/connect/?bindings=')+json);
       debug(libUrls.api(helper.rootUrl, 'events', 'v1', '/connect/?bindings')+json);
       debug('trying to connect to api');
-      var pass, fail;
-      var resolve = new Promise((resolve, reject) => {pass = resolve; fail= reject;});
+      let pass, fail;
+      const resolve = new Promise((resolve, reject) => {
+        pass = resolve;
+        fail = reject;
+      });
       return {
-        es:      es,
-        resolve: resolve,
-        pass:    pass,
-        fail:    fail, 
+        evtSource,
+        resolve,
+        pass,
+        fail, 
       };
     };
 


### PR DESCRIPTION
I created a component `listeners` to handle `PulseListener`s 
Now I can use `fakeMessage` in tests along with updating them to use the new format
I have disabled the `Exchange does not exist` test for now (it had an uncaught exception, I couldn;t figure out). Will fix this along with other tests
