### PR TITLE
Updates to work with client in tc-tools

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -36,6 +36,3 @@ test:
 
   server:
     port:           12345
-
-  pulse:
-    fake:           true

--- a/src/api.js
+++ b/src/api.js
@@ -88,6 +88,7 @@ builder.declare({
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
+      'Access-Control-Allow-Origin': '*',
     });
     headWritten = true;
 

--- a/src/api.js
+++ b/src/api.js
@@ -16,7 +16,7 @@ let builder = new APIBuilder({
   version: 'v1',
   context: ['listeners'],
   errorCodes: {
-    NoReconnects:   204,  // Not supporting automatic reconnects from EventSource
+    NoReconnects: 204,  // Not supporting automatic reconnects from EventSource
   },
 });
 
@@ -63,13 +63,12 @@ builder.declare({
   // Add input validation yml
   title: 'Events-Api',
 }, async function(req, res) {
-  debug('hello');
 
   // If the last event id is '-', send a 204 error blocking all reconnects.
   // No reconnect on 204 is not yet supported on EventSource.
   // Clients using that need to use es.close() to stop error messages.
   if (req.headers['last-event-id']) {
-    debug('no reconnect');
+    debug('no reconnects allowed');
     return res.reportError('NoReconnects', 'Not allowing reconnects');
   }
 
@@ -88,9 +87,8 @@ builder.declare({
     try {
       const event = `event: ${kind}\ndata: ${JSON.stringify(data)}\nid: -\n\n`;
       res.write(event);
-      debug('..sendEvent', event); 
+      debug('sending event : ', kind); 
     } catch (err) {
-      debug('Error in sendEvent:');
       abort(err);
     }
   };
@@ -133,7 +131,7 @@ builder.declare({
     ]);
 
   } catch (err) {
-    debug('Error : %j', err.message, err.code);
+    debug('Error : %j', err.code, err.message);
     var errorMessage = 'Unknown Internal Error';
     if (err.code === 404) {
       errorMessage = err.message;
@@ -150,7 +148,6 @@ builder.declare({
 
     // TODO : Find a suitable error message depending on err.
     // Most likely these will be PulseListener errors.
-    debug('Error message : ', errorMessage);
     sendEvent('error', errorMessage);
   } finally {
 
@@ -159,7 +156,6 @@ builder.declare({
     }
 
     if (pingEvent) {
-      debug('unping');
       clearInterval(pingEvent);
     }
     // Close the listener

--- a/src/api.js
+++ b/src/api.js
@@ -15,6 +15,9 @@ let builder = new APIBuilder({
   serviceName: 'events',
   version: 'v1',
   context: ['listeners'],
+  errorCodes: {
+    NoReconnects:   204,  // Not supporting automatic reconnects from EventSource
+  },
 });
 
 // Returns JSON.parse(bindings) if everything goes well
@@ -66,7 +69,7 @@ builder.declare({
   // No reconnect on 204 is not yet supported on EventSource.
   // Clients using that need to use es.close() to stop error messages.
   if (req.headers['last-event-id']) {
-    return res.reportError(204, 'Not allowing reconnects');
+    return res.reportError('NoReconnects', 'Not allowing reconnects');
   }
 
   let abort, headWritten, pingEvent;

--- a/src/api.js
+++ b/src/api.js
@@ -72,7 +72,7 @@ builder.declare({
     return res.reportError('NoReconnects', 'Not allowing reconnects');
   }
 
-  let abort, headWritten, pingEvent;
+  let abort, headWritten, pingEvent, idleTimeout;
   const aborted = new Promise((resolve, reject) => abort = reject);
 
   const sendEvent = (kind, data={}) => {
@@ -100,7 +100,7 @@ builder.declare({
     var listener = await this.listeners.createListener(json_bindings);
     sendEvent('ready');
     const idleMessage = {code:404, message:'No messages received for 20s. Aborting...'};
-    let idleTimeout = setTimeout(() => abort(idleMessage), 20*1000);
+    idleTimeout = setTimeout(() => abort(idleMessage), 20*1000);
     
     listener.on('message', message => {
       sendEvent('message', message);
@@ -142,6 +142,10 @@ builder.declare({
     debug('Error message : ', errorMessage);
     sendEvent('error', errorMessage);
   } finally {
+
+    if (idleTimeout) {
+      clearInterval(idleTimeout);
+    }
 
     if (pingEvent) {
       debug('unping');

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -45,9 +45,8 @@ class Listeners {
       }));
 
       this.listeners.push(listener);
-      await listener.resume();
-
       return listener;
+      
     } catch (err) {
       err.code = 404;
       debug(err);


### PR DESCRIPTION
1. Attempting to set up a connection using EventSource in the browser throws an error in the console:
`Request header field Cache-Control is not allowed by Access-Control-Allow-Headers in preflight response..`
Thus `tc-lib-api` was updated to v12.3.0 to add `Cache-Control` to `Access-Control-Allow-Headers`

2. Also I removed 
```yaml
test: 
  pulse:
    fake:   true
```
from `config.yml` to allow me to run the server on `localhost` with real pulse creds in `user-config.yml`
